### PR TITLE
fix project image to appear on PYPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![REFRAPY LOGO](https://github.com/AlgoSismos/Refrapy/blob/main/src/refrapy/images/refrapy_logo.png)
+![REFRAPY LOGO](https://raw.githubusercontent.com/AlgoSismos/Refrapy/refs/heads/main/src/refrapy/images/refrapy_logo.png)
 
 Refrapy is a graphical application for seismic refraction data analysis. It is written in Python and uses 
 open source libraries from numerical and geophysics python communities to 


### PR DESCRIPTION
Project logo is not appearing on PyPI repository. 

This fix is following someone else who got into the [same issue](https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github). 

TL;DR Just copy the link to the raw repository data provided by GitHub.